### PR TITLE
Remove download links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,11 +20,6 @@
 
           <h1 id="project_title">Reproducible</h1>
           <h2 id="project_tagline">Reproducibility and Open Science Working Group </h2>
-
-            <section id="downloads">
-              <a class="zip_download_link" href="https://github.com/uwescience/reproducible/zipball/master">Download this project as a .zip file</a>
-              <a class="tar_download_link" href="https://github.com/uwescience/reproducible/tarball/master">Download this project as a tar.gz file</a>
-            </section>
         </header>
     </div>
 


### PR DESCRIPTION
This is not software so there is probably no sense having links to download the repository as a ZIP.
